### PR TITLE
Makefile: clean up

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,9 +22,6 @@ doc: Makefile.coq
 install-doc: doc
 	$(MAKE) -f Makefile.coq install-doc
 
-%: Makefile.coq
-	$(MAKE) -f Makefile.coq "$@"
-
 clean: Makefile.coq
-	$(MAKE) -f Makefile.coq clean
-	rm -f _CoqProject Makefile.coq
+	$(MAKE) -f Makefile.coq cleanall
+	rm -f _CoqProject Makefile.coq Makefile.coq.conf


### PR DESCRIPTION
- Makes the `clean` command clean better (cleanall also removes `.aux` files).
- Removes the `%` target to avoid these warnings:

```
make: Circular paco.v <- Makefile.coq dependency dropped.
make: Circular examples.v <- Makefile.coq dependency dropped.
make: Circular paco8.v <- Makefile.coq dependency dropped.
make: Circular gpaco5.v <- Makefile.coq dependency dropped.
(...)
```