### PR TITLE
Remove unused Import Omega

### DIFF
--- a/src/examples.v
+++ b/src/examples.v
@@ -4,7 +4,7 @@
 (** printing -> $\rightarrow$ #&rarr;# *)
 (** printing /\ $\land$ #&and;# *)
 
-Require Import ZArith List String Omega.
+Require Import ZArith List String.
 Require Import Paco.paco.
 Import ListNotations.
 


### PR DESCRIPTION
This was causing paco to fail to build with `coq.dev` because `Omega` has been removed.